### PR TITLE
sec: raise undici override to non-vulnerable range

### DIFF
--- a/CalcGachaProbTool/package-lock.json
+++ b/CalcGachaProbTool/package-lock.json
@@ -783,16 +783,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@angular/build/node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@angular/cdk": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-6.3.1.tgz",
@@ -15884,6 +15874,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
+      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/CalcGachaProbTool/package.json
+++ b/CalcGachaProbTool/package.json
@@ -53,6 +53,6 @@
   },
   "overrides": {
     "picomatch": "4.0.4",
-    "undici": "7.16.0"
+    "undici": "7.24.0"
   }
 }

--- a/docs/security-maintenance.md
+++ b/docs/security-maintenance.md
@@ -14,3 +14,4 @@
 - 併せて `package.json` の `e2e` スクリプトを削除し、現行運用（build/test/lint）に合わせた。
 - `CalcGachaProbTool/package.json` に `overrides` を追加し、`picomatch` と `undici` を安全版へ固定。
 - `package-lock.json` を再解決し、Angular 側の残存アラート（`picomatch` / `undici`）の解消を狙う。
+- `undici` は初回固定値が脆弱範囲内だったため、`7.24.0` へ再固定して `CalcGachaProbTool` 側の監査結果を `0 vulnerabilities` に更新。


### PR DESCRIPTION
## 概要
- CalcGachaProbTool の `undici` override を 7.24.0 へ更新
- package-lock.json を再解決
- docs/security-maintenance.md を更新

## 対応対象（Dependabot alerts）
- #435 / #434 / #437 (undici)

## 確認
- CalcGachaProbTool で `npm install --package-lock-only --legacy-peer-deps` 後に `found 0 vulnerabilities`

## docs
- 更新済み（docs/security-maintenance.md）
