### PR TITLE
ci: switch react workflow to npm + node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,20 +49,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: yarn
-          cache-dependency-path: gacha-prob-calculator/yarn.lock
-
-      - name: Enable Corepack
-        run: corepack enable
+          node-version: 20
+          cache: npm
+          cache-dependency-path: gacha-prob-calculator/package-lock.json
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npm ci
 
       - name: Build
         env:
           CI: false
-        run: yarn build
+        run: npm run build
 
       - name: Test
-        run: CI=true yarn test --watchAll=false
+        run: npm run test:ci


### PR DESCRIPTION
## 概要
- React CI ジョブを yarn から npm 実行へ切替
- Node.js を 20 に固定
- install/build/test を Vite/Vitest 用コマンドへ更新

## 変更点
- `npm ci`
- `npm run build`
- `npm run test:ci`

## 補足
- Angular ジョブ（pushのみ、continue-on-error）は現行方針を維持
