### PR TITLE
docs: enable npm dependabot and update migration docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/CalcGachaProbTool"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "npm"
+    directory: "/gacha-prob-calculator"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"

--- a/docs/directory-overview.md
+++ b/docs/directory-overview.md
@@ -39,19 +39,23 @@
 - `src/`: アプリケーションコード
 - `public/`: 静的ファイル
 - `build/`: ビルド成果物
+- `index.html`: Vite エントリHTML
+- `vite.config.ts`: Vite / Vitest 設定
 - `package.json`: 実行スクリプトと依存関係
+- `package-lock.json`: npm 依存ロックファイル（正）
 
 主な実行コマンド:
 
-- `npm start`（または `yarn start`）
-- `npm run build`（または `yarn build`）
-- `npm test`（または `yarn test`）
+- `npm run dev`
+- `npm run build`
+- `npm run test`
+- `npm run test:ci`
 
 ## 補足
 
 - ルートの `README.md` はアプリの目的と機能説明です。
 - 実装は Angular 版と React 版が共存しているため、作業対象ディレクトリを先に確認してください。
 - CI は `.github/workflows/ci.yml` で管理し、Angular/React を別ジョブで実行します。
-- CI の実行環境は、Angular を Node 10、React を Node 18 として分離しています。
+- CI の実行環境は、Angular を Node 10、React を Node 20 として分離しています。
 - Angular ジョブは既存依存更新で不安定なため、当面は non-blocking（失敗時もPR全体をブロックしない）で運用します。
 - 依存更新期間中は、Angular ジョブを `push(master)` 時のみ実行し、PR では React/CodeQL を優先して検証します。

--- a/docs/security-maintenance.md
+++ b/docs/security-maintenance.md
@@ -15,3 +15,7 @@
 - `CalcGachaProbTool/package.json` に `overrides` を追加し、`picomatch` と `undici` を安全版へ固定。
 - `package-lock.json` を再解決し、Angular 側の残存アラート（`picomatch` / `undici`）の解消を狙う。
 - `undici` は初回固定値が脆弱範囲内だったため、`7.24.0` へ再固定して `CalcGachaProbTool` 側の監査結果を `0 vulnerabilities` に更新。
+- `gacha-prob-calculator` は CRA (`react-scripts`) から Vite + React 18 + Vitest へ移行。
+- React 側の依存管理を `npm` に統一し、`yarn.lock` を廃止して `package-lock.json` を正規ロックファイルに変更。
+- CI の React ジョブを Node 20 + npm 実行（`npm ci` / `npm run build` / `npm run test:ci`）へ更新。
+- Dependabot を `CalcGachaProbTool` / `gacha-prob-calculator` の npm 監視で有効化し、継続的な依存更新体制を確立。


### PR DESCRIPTION
## 概要
- Dependabot を npm 2ディレクトリ監視で有効化
- React 基盤移行（CRA脱却 / npm統一 / Vitest移行）を docs に記録
- directory overview を Vite + npm 運用に更新

## 変更点
- `.github/dependabot.yml` を実運用構成へ置換
- `docs/security-maintenance.md` 追記
- `docs/directory-overview.md` 追記
